### PR TITLE
fix string length calculate issue with unicode

### DIFF
--- a/SwiftUtils/RSAUtils.swift
+++ b/SwiftUtils/RSAUtils.swift
@@ -101,7 +101,7 @@ public class RSAUtils {
      */
     @available(iOS, introduced: 1.2.0)
     @discardableResult public static func addRSAPrivateKey(_ privkeyBase64: String, tagName: String) throws -> SecKey? {
-        let fullRange = NSRange(location: 0, length: privkeyBase64.count)
+        let fullRange = NSRange(location: 0, length: privkeyBase64.lengthOfBytes(using: .utf8))
         let regExp = try! NSRegularExpression(pattern: "(-----BEGIN.*?-----)|(-----END.*?-----)|\\s+", options: [])
         let myPrivkeyBase64 = regExp.stringByReplacingMatches(in: privkeyBase64, options: [], range: fullRange, withTemplate: "")
         return try addRSAPrivateKey(base64Decode(myPrivkeyBase64), tagName: tagName)
@@ -220,8 +220,9 @@ public class RSAUtils {
      */
     @available(iOS, introduced: 1.2.0)
     public static func addRSAPublicKey(_ pubkeyBase64: String, tagName: String) throws -> SecKey? {
+        let fullRange = NSRange(location: 0, length: pubkeyBase64.lengthOfBytes(using: .utf8))
         let regExp = try! NSRegularExpression(pattern: "(-----BEGIN.*?-----)|(-----END.*?-----)|\\s+", options: [])
-        let myPubkeyBase64 = regExp.stringByReplacingMatches(in: pubkeyBase64, options: [], range: NSRange(location: 0, length: pubkeyBase64.count), withTemplate: "")
+        let myPubkeyBase64 = regExp.stringByReplacingMatches(in: pubkeyBase64, options: [], range: fullRange, withTemplate: "")
         return try addRSAPublicKey(base64Decode(myPubkeyBase64), tagName: tagName)
     }
 


### PR DESCRIPTION
fix unicode string count issue
for example, input string as
````
let test = """
-----BEGIN PUBLIC KEY-----\r\ntest\r\n-----END PUBLIC KEY-----
"""
````
test.count will be 56
in this case, regExp.stringByReplacingMatches result will be 
````
test-----ENDPUBLICKEY-----
````

but correct count should be test.lengthOfBytes(using: .utf8) = 58
and regExp.stringByReplacingMatches result will be
````
test
````
